### PR TITLE
Don't simplify parameters to grid-template-columns and -rows

### DIFF
--- a/src/main/java/net/logicsquad/minifier/css/CSSMinifier.java
+++ b/src/main/java/net/logicsquad/minifier/css/CSSMinifier.java
@@ -533,7 +533,8 @@ public class CSSMinifier extends AbstractMinifier {
 
 		private void simplifyParameters() {
 			if (this.property.equals("background-size") || this.property.equals("quotes")
-					|| this.property.equals("transform-origin"))
+					|| this.property.equals("transform-origin") || this.property.equals("grid-template-columns")
+					|| this.property.equals("grid-template-rows"))
 				return;
 
 			StringBuffer newContents = new StringBuffer();

--- a/src/test/java/net/logicsquad/minifier/css/CSSMinifierTest.java
+++ b/src/test/java/net/logicsquad/minifier/css/CSSMinifierTest.java
@@ -17,7 +17,7 @@ public class CSSMinifierTest extends AbstractMinifierTest {
 	 * Indexes for input/output resources
 	 */
 	private static final List<String> RESOURCES = Arrays.asList("01", "02", "03", "04", "05", "06", "07", "08", "09", "10", "11", "12", "13", "14", "15", "16",
-			"17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28");
+			"17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29");
 
 	/**
 	 * Extension for resource files

--- a/src/test/resources/input/test-29.css
+++ b/src/test/resources/input/test-29.css
@@ -1,0 +1,5 @@
+@charset "UTF-8";
+#test-29 {
+    grid-template-columns: 1fr 1fr;
+    grid-template-rows: 1fr 1fr;
+}

--- a/src/test/resources/output/test-29.css
+++ b/src/test/resources/output/test-29.css
@@ -1,0 +1,1 @@
+@charset "UTF-8";#test-29{grid-template-columns:1fr 1fr;grid-template-rows:1fr 1fr}


### PR DESCRIPTION
All parameters for grid-template-columns and grid-template-rows are significant even when identical.
i.e. `grid-template-columns: 1fr 1fr` can't be simplified to `grid-template-columns: 1fr`.

I added a test case (test-29.css) to showcase and reproduce the problem and added both CSS properties to the initial guard clause in `CSSMinifier.Part.simplifyParameters()` to fix the issue.

I am pretty sure that there are even more such cases that should not be simplified, but I am not a CSS expert.

NB: It might make sense to keep a deny-list for the properties which should be exempt from having their parameters simplified. I still only added another two cases to the guard clause to keep the change as simple as possible.